### PR TITLE
tf.Variable ctor call results in ValueError due to initializer should be passed as lambda

### DIFF
--- a/attention.py
+++ b/attention.py
@@ -57,10 +57,12 @@ def attention(inputs, attention_size, time_major=False, return_alphas=False):
 
     hidden_size = inputs.shape[2].value  # D value - hidden size of the RNN layer
 
+    initializer = tf.random_normal_initializer(stddev=0.1)
+
     # Trainable parameters
-    w_omega = tf.Variable(tf.random_normal([hidden_size, attention_size], stddev=0.1))
-    b_omega = tf.Variable(tf.random_normal([attention_size], stddev=0.1))
-    u_omega = tf.Variable(tf.random_normal([attention_size], stddev=0.1))
+    w_omega = tf.get_variable(name="w_omega", shape=[hidden_size, attention_size], initializer=initializer)
+    b_omega = tf.get_variable(name="b_omega", shape=[attention_size], initializer=initializer)
+    u_omega = tf.get_variable(name="u_omega", shape=[attention_size], initializer=initializer)
 
     with tf.name_scope('v'):
         # Applying fully connected layer with non-linear activation to each of the B*T timestamps;


### PR DESCRIPTION
Hello Ilya,
At first would like to thank you for this repository (which becomes a part of AREkit framework), this helps me a lot and especially experiment with the related architecture.
I'm doing a specific relation extraction task, which results in sentence classification. I have experiment with this approach as an attention over sentence embeddings, and the latter results in tf.while_loop application.
During experiment i have encountered the following value error:  
"Initializer for variable is from inside a control-flow construct, such as a loop or conditional. When creating a variable inside a loop or conditional, use a lambda as the initializer"

So, here is a fix. And, fyi tf.get_variable is a more flexible in terms of initialization.

Спасибо!

screenshot as log, to clarify written above :)
![Screenshot_2019-12-20_22-13-21](https://user-images.githubusercontent.com/14871187/71285453-404b2100-2376-11ea-8c6f-0d0c56380d68.png)
